### PR TITLE
First comit of new dbadapters.

### DIFF
--- a/local_db.py
+++ b/local_db.py
@@ -20,7 +20,7 @@ issues.
 
 from os import path
 import ast
-from meerkat_auth import db
+from meerkat_auth import app
 import argparse
 import logging
 from meerkat_auth.role import Role
@@ -59,11 +59,11 @@ if all(arg is False for arg in args_dict.values()):
         args_dict[arg] = True
 
 if args.clear:
-    db.drop()
+    app.db.drop()
 
 
 if args.setup:
-    db.setup()
+    app.db.setup()
 
 if args.populate:
     logging.info('Populating dev db')
@@ -474,8 +474,8 @@ if args.populate:
 
 if args.list:
     logging.info("Listing all users")
-    results = db.get_all_users()
+    results = app.db.get_all(app.config['USERS'])
     logging.info("\n".join([str(User(**x)) for x in results]))
     logging.info("Listing all roles")
-    results = db.get_all_roles()
+    results = app.db.get_all(app.config['ROLES'])
     logging.info("\n".join([str(Role(**x)) for x in results]))

--- a/meerkat_auth/__init__.py
+++ b/meerkat_auth/__init__.py
@@ -8,6 +8,7 @@ from flask.ext.babel import Babel
 from raven.contrib.flask import Sentry
 import os
 
+
 # Create the Flask app
 app = Flask(__name__)
 babel = Babel(app)
@@ -20,6 +21,10 @@ if app.config["SENTRY_DNS"]:
     sentry = Sentry(app, dsn=app.config["SENTRY_DNS"])
 else:
     sentry = None
+
+# The DB is interfaced through an adapter specified in config.
+from meerkat_auth import db_adapters
+db = getattr(db_adapters, app.config['DB_ADAPTER'])()
 
 from meerkat_auth.views.users import users_blueprint
 from meerkat_auth.views.roles import roles_blueprint

--- a/meerkat_auth/__init__.py
+++ b/meerkat_auth/__init__.py
@@ -24,7 +24,7 @@ else:
 
 # The DB is interfaced through an adapter specified in config.
 from meerkat_auth import db_adapters
-db = getattr(db_adapters, app.config['DB_ADAPTER'])()
+app.db = getattr(db_adapters, app.config['DB_ADAPTER'])()
 
 from meerkat_auth.views.users import users_blueprint
 from meerkat_auth.views.roles import roles_blueprint

--- a/meerkat_auth/config.py
+++ b/meerkat_auth/config.py
@@ -35,6 +35,7 @@ class Config(object):
         "DB_URL",
         "https://dynamodb.eu-west-1.amazonaws.com"
     )
+    DB_ADAPTER = os.environ.get("MEERKAT_DB_ADAPTER", "DynamoDBAdapter")
     ROOT_URL = os.environ.get("MEERKAT_AUTH_ROOT", "")
 
     SENTRY_DNS = os.environ.get('SENTRY_DNS', '')

--- a/meerkat_auth/db_adapters.py
+++ b/meerkat_auth/db_adapters.py
@@ -1,0 +1,385 @@
+import boto3
+import psycopg2
+import logging
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from psycopg2 import sql
+from meerkat_auth import app
+from psycopg2.extras import Json
+
+
+class DynamoDBAdapter():
+
+    STRUCTURE = {
+        app.config['ROLES']: {
+            "TableName": app.config['ROLES'],
+            "AttributeDefinitions": [
+                {'AttributeName': 'country', 'AttributeType': 'S'},
+                {'AttributeName': 'role', 'AttributeType': 'S'}
+            ],
+            "KeySchema": [
+                {'AttributeName': 'country', 'KeyType': 'HASH'},
+                {'AttributeName': 'role', 'KeyType': 'RANGE'}
+            ],
+            "ProvisionedThroughput": {
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5
+            }
+        },
+        app.config['USERS']: {
+            "TableName": app.config['USERS'],
+            "AttributeDefinitions": [
+                {'AttributeName': 'username', 'AttributeType': 'S'}
+            ],
+            "KeySchema": [
+                {'AttributeName': 'username', 'KeyType': 'HASH'}
+            ],
+            "ProvisionedThroughput": {
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5
+            }
+        }
+    }
+
+    def __init__(self):
+        # The database resource
+        self.conn = boto3.resource(
+            'dynamodb',
+            endpoint_url=app.config['DB_URL'],
+            region_name='eu-west-1'
+        )
+
+    def drop(self):
+        try:
+            logging.info('Cleaning the dev db.')
+            response = self.conn.Table(app.config['USERS']).delete()
+            logging.debug(response)
+            response = self.conn.Table(app.config['ROLES']).delete()
+            logging.debug(response)
+            logging.info('Cleaned the db.')
+
+        except Exception as e:
+            logging.error(e)
+            logging.error('There has been error, probably because no tables'
+                         'currently exist. Skipping the clean process.')
+
+    def setup(self):
+        logging.info('Creating dev db')
+        for table, structure in DynamoDBAdapter.STRUCTURE.items():
+            response = self.conn.create_table(**structure)
+            logging.debug(response)
+
+    def read(self, table, keys, attributes=[]):
+        args = {'Key': keys}
+        if attributes:
+            args['ProjectionExpression'] = ", ".join(attributes)
+        table = self.conn.Table(table)
+        return table.get_item(**args).get('Item', None)
+
+    def write(self, table, keys, attributes):
+        for key, value in attributes.items():
+            attributes[key] = {'Value': value, 'Action': 'PUT'}
+        table = self.conn.Table(table)
+        return table.update_item(
+            Key=keys,
+            AttributeUpdates=attributes
+        )
+
+    def delete(self, table, keys):
+        self.table = self.conn.Table(table)
+        return table.delete_item(Key=keys)
+
+    def get_all_roles(self, countries=[]):
+        table = self.conn.Table(app.config['ROLES'])
+        if not countries:
+            # If no country is specified, get all roles and return as list.
+            return table.scan({}).get("Items", [])
+        else:
+            roles = []
+            # Load data separately for each country because can't query for OR.
+            for country in countries:
+                roles = roles + table.query(
+                    KeyConditions={
+                        'country': {
+                            'AttributeValueList': [country],
+                            'ComparisonOperator': 'EQ'
+                        }
+                    }
+                ).get("Items", [])
+            return roles
+
+    def get_all_users(self, countries=[], attributes=[]):
+        table = self.conn.Table(app.config['USERS'])
+
+        # Assemble scan arguments programatically, by building a dictionary.
+        kwargs = {}
+
+        # Include AttributesToGet if any are specified.
+        # By not including them we get them all.
+        if attributes:
+            kwargs["AttributesToGet"] = attributes
+
+        if not countries:
+            # If no country is specified, get all users and return as list.
+            return table.scan(**kwargs).get("Items", [])
+
+        else:
+            users = {}
+            # Load data separately for each country
+            # ...because Scan can't perform OR on CONTAINS
+            for country in countries:
+
+                kwargs["ScanFilter"] = {
+                    'countries': {
+                        'AttributeValueList': [country],
+                        'ComparisonOperator': 'CONTAINS'
+                    }
+                }
+
+                # Get and combine the users together in a no-duplications dict.
+                for user in table.scan(**kwargs).get("Items", []):
+                    users[user["username"]] = user
+
+            # Convert the dict to a list by getting values.
+            return list(users.values())
+
+
+class PostgreSQLAdapter():
+
+    STRUCTURE = {
+        app.config['USERS']: [
+            ("username", sql.SQL("username VARCHAR(50) PRIMARY KEY")),
+            ("data",  sql.SQL("data JSON"))
+        ],
+        app.config['ROLES']: [
+            ("country", sql.SQL("country VARCHAR(50)")),
+            ("role", sql.SQL("role VARCHAR(50)")),
+            ("data", sql.SQL("data JSON"))
+        ]
+    }
+
+    def drop(self):
+        try:
+            logging.info("Dropping database")
+            conn = psycopg2.connect(
+                dbname="postgres",
+                user="postgres",
+                host="db"
+            )
+            # Cannot drop or create from within a DB transaction.
+            # http://initd.org/psycopg/docs/connection.html#connection.autocommit
+            with conn.cursor() as cur:
+                conn.autocommit = True
+                cur.execute("DROP DATABASE meerkat_auth;")
+                conn.close()
+
+        except psycopg2.ProgrammingError:
+            logging.info("No database exists to drop.")
+
+    def setup(self):
+        # TODO: Backoff until postgres container running.
+        self._create_db()
+        self._create_tables()
+
+    def list(self):
+        for table in PostgreSQLAdapter.STRUCTURE.keys():
+            logging.info("Listing all records in {} table".format(table))
+            cur = self.conn().cursor()
+            cur.execute(sql.SQL("SELECT data from {}").format(
+                sql.Identifier(table)
+            ))
+            results = [x[0] for x in cur.fetchall()]
+            cur.close()
+            logging.info(results)
+
+    def _create_db(self):
+        try:
+            logging.info("Checking if db exist.")
+            self.conn = psycopg2.connect(
+                dbname="meerkat_auth",
+                user="postgres",
+                host="db"
+            )
+            logging.info("DB exists.")
+
+        except psycopg2.OperationalError:
+            logging.info("DB needs to be created.")
+            conn = psycopg2.connect(
+                dbname="postgres",
+                user="postgres",
+                host="db"
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            conn.cursor().execute("CREATE DATABASE meerkat_auth")
+            conn.commit()
+            conn.close()
+            self.conn = psycopg2.connect(
+                dbname="meerkat_auth",
+                user="postgres",
+                host="db"
+            )
+            logging.info("DB created and connection established.")
+            self._create_tables()
+
+    def _create_tables(self):
+        for table, structure in PostgreSQLAdapter.STRUCTURE.items():
+            # Only create non-existant tables, so first check if table exists.
+            try:
+                logging.info("Checking if table {} exists.".format(table))
+                cur = self.conn.cursor()
+                cur.execute(sql.SQL("SELECT * FROM {} LIMIT 1;").format(
+                    sql.Identifier(table)  # Always protect constructed SQL
+                ))
+                logging.info("Table {} exists.".format(table))
+
+            except psycopg2.ProgrammingError:
+                logging.info("Table {} needs to be created.".format(table))
+                # Construct secure SQL query.
+                structure = sql.SQL(", ").join(map(lambda x: x[1], structure))
+                query = sql.SQL("CREATE TABLE {} ({});").format(
+                    sql.Identifier(table),
+                    structure
+                )
+                logging.debug("Create query: ".format(query.as_string(self.conn)))
+
+                # Create a cursor and execute the table creation DB query.
+                self.conn.rollback()
+                cur = self.conn.cursor()
+                cur.execute(query)
+                self.conn.commit()
+
+                logging.info("Table {} created".format(table))
+
+    def read(self, table, key, attributes=[]):
+        # Securely SQL stringify the attributes
+        if attributes:
+            tmp = [sql.SQL("data->>{}").format(sql.Literal(a)) for a in attributes]
+            attributes = sql.SQL(", ").join(tmp)
+        else:
+            attributes = sql.SQL("data")
+
+        # Securely SQL stringify the conditions
+        conds = []
+        for k, v in key.items():
+            conds += [sql.SQL("{}={}").format(sql.Identifier(k), sql.Literal(v))]
+        conditions = sql.SQL(" AND ").join(conds)
+
+        # Form the secure SQL query
+        query = sql.SQL("SELECT {} from {} where {};").format(
+            attributes,
+            sql.Identifier(table),
+            conditions
+        )
+        logging.debug("Read query: {}".format(query.as_string(self.conn)))
+
+        # Get and return the db result if it exists.
+        # Function only searches on keys so should always be single result
+        cur = self.conn.cursor()
+        cur.execute(query)
+        result = cur.fetchone()
+        cur.close()
+        if result:
+            return result[0]
+        else:
+            return None  # The result may not exist
+
+    def write(self, table, key, attributes):
+        # Add the key data to the json blob.
+        attributes = {**key, **attributes}
+        # Stringify the insert data
+        data = {**key, 'data': Json(attributes)}
+        values = sql.SQL(", ").join(map(
+            lambda x: sql.Literal(data[x[0]]),
+            PostgreSQLAdapter.STRUCTURE[table]
+        ))
+
+        # Securely build sql query to avoid sql injection.
+        query = sql.SQL("INSERT INTO {} VALUES ({});").format(
+            sql.Identifier(table),
+            values
+        )
+        logging.debug("Write query: {}".format(query.as_string(self.conn)))
+
+        # Insert the data
+        cur = self.conn.cursor()
+        cur.execute(query)
+        self.conn.commit()
+        cur.close()
+
+    def delete(self, table, key):
+        # Securely SQL stringify the conditions
+        conditions = sql.SQL(" AND ").join(map(
+            lambda k, v: sql.SQL("{}={}").format(sql.Identifier(k), sql.Literal(v)),
+            key.items()
+        ))
+
+        # Securely build sql query to avoid sql injection.
+        query = sql.SQL("DELETE from {} where {};").format(
+            sql.Identifier(table),
+            conditions
+        )
+        logging.debug("Delete query: {}".format(query.as_string(self.conn)))
+
+        # Execute the delete query
+        cur = self.conn.cursor()
+        cur.execute(query)
+        self.conn.commit()
+        cur.close()
+
+    def get_all_roles(self, countries=[]):
+        # Securely compose sql list of conditions.
+        if countries:
+            conditions = sql.SQL(" where country in ({})").format(
+                sql.SQL(", ").join([sql.Literal(x) for x in countries])
+            )
+        else:
+            conditions = sql.SQL("")
+
+        # Build the secure SQL query
+        query = sql.SQL("SELECT data from {}{};").format(
+            sql.Identifier(app.config['ROLES']),
+            conditions
+        )
+        logging.debug("Read query: {}".format(query.as_string(self.conn)))
+
+        # Execute and fetch JSON data as a list of dicts
+        # (Key data is merged into JSON data before writing to db.)
+        cur = self.conn.cursor()
+        cur.execute(query)
+        results = [x[0] for x in cur.fetchall()]  # Just JSON data
+        cur.close()
+        return results
+
+    def get_all_users(self, countries=[], attributes=[]):
+        # Securely compose sql list of attributes.
+        if attributes:
+            attributes = sql.SQL(", ").join(map(
+                lambda x: sql.SQL("data->>{}").format(sql.Literal(x)),
+                attributes
+            ))
+        else:
+            attributes = sql.SQL("data")
+
+        # Securely compose sql list of conditions.
+        if countries:
+            condition = sql.SQL(" where data->>'country' in ({});").format(
+                sql.SQL(", ").join([sql.Literal(x) for x in countries])
+            )
+        else:
+            condition = sql.SQL("")
+
+        # Securely build sql query to avoid sql injection.
+        query = sql.SQL("SELECT {} from {}{};").format(
+            attributes,
+            sql.Identifier(app.config['USERS']),
+            condition
+        )
+        logging.debug("Read query: {}".format(query.as_string(self.conn)))
+
+        # Execute and fetch only JSON data as a list of dicts
+        # (Don't need key data as it is merged into JSON data during db write.)
+        cur = self.conn.cursor()
+        cur.execute(query)
+        results = cur.fetchall()
+        results = [x[0] for x in results]
+        cur.close()
+        return results

--- a/meerkat_auth/db_adapters.py
+++ b/meerkat_auth/db_adapters.py
@@ -9,39 +9,37 @@ from psycopg2.extras import Json
 
 class DynamoDBAdapter():
 
-    STRUCTURE = {
-        app.config['ROLES']: {
-            "TableName": app.config['ROLES'],
-            "AttributeDefinitions": [
-                {'AttributeName': 'country', 'AttributeType': 'S'},
-                {'AttributeName': 'role', 'AttributeType': 'S'}
-            ],
-            "KeySchema": [
-                {'AttributeName': 'country', 'KeyType': 'HASH'},
-                {'AttributeName': 'role', 'KeyType': 'RANGE'}
-            ],
-            "ProvisionedThroughput": {
-                'ReadCapacityUnits': 5,
-                'WriteCapacityUnits': 5
-            }
-        },
-        app.config['USERS']: {
-            "TableName": app.config['USERS'],
-            "AttributeDefinitions": [
-                {'AttributeName': 'username', 'AttributeType': 'S'}
-            ],
-            "KeySchema": [
-                {'AttributeName': 'username', 'KeyType': 'HASH'}
-            ],
-            "ProvisionedThroughput": {
-                'ReadCapacityUnits': 5,
-                'WriteCapacityUnits': 5
+    def __init__(self):
+        self.structure = {
+            app.config['ROLES']: {
+                "TableName": app.config['ROLES'],
+                "AttributeDefinitions": [
+                    {'AttributeName': 'country', 'AttributeType': 'S'},
+                    {'AttributeName': 'role', 'AttributeType': 'S'}
+                ],
+                "KeySchema": [
+                    {'AttributeName': 'country', 'KeyType': 'HASH'},
+                    {'AttributeName': 'role', 'KeyType': 'RANGE'}
+                ],
+                "ProvisionedThroughput": {
+                    'ReadCapacityUnits': 5,
+                    'WriteCapacityUnits': 5
+                }
+            },
+            app.config['USERS']: {
+                "TableName": app.config['USERS'],
+                "AttributeDefinitions": [
+                    {'AttributeName': 'username', 'AttributeType': 'S'}
+                ],
+                "KeySchema": [
+                    {'AttributeName': 'username', 'KeyType': 'HASH'}
+                ],
+                "ProvisionedThroughput": {
+                    'ReadCapacityUnits': 5,
+                    'WriteCapacityUnits': 5
+                }
             }
         }
-    }
-
-    def __init__(self):
-        # The database resource
         self.conn = boto3.resource(
             'dynamodb',
             endpoint_url=app.config['DB_URL'],
@@ -49,22 +47,29 @@ class DynamoDBAdapter():
         )
 
     def drop(self):
+        logging.info('Cleaning the dev db.')
+
         try:
-            logging.info('Cleaning the dev db.')
             response = self.conn.Table(app.config['USERS']).delete()
             logging.debug(response)
-            response = self.conn.Table(app.config['ROLES']).delete()
-            logging.debug(response)
-            logging.info('Cleaned the db.')
-
         except Exception as e:
             logging.error(e)
             logging.error('There has been error, probably because no tables'
-                         'currently exist. Skipping the clean process.')
+                          'currently exist. Skipping the clean process.')
+
+        try:
+            response = self.conn.Table(app.config['ROLES']).delete()
+            logging.debug(response)
+        except Exception as e:
+            logging.error(e)
+            logging.error('There has been error, probably because no tables'
+                          'currently exist. Skipping the clean process.')
+
+        logging.info('Cleaned the db.')
 
     def setup(self):
         logging.info('Creating dev db')
-        for table, structure in DynamoDBAdapter.STRUCTURE.items():
+        for table, structure in self.structure.items():
             response = self.conn.create_table(**structure)
             logging.debug(response)
 
@@ -88,27 +93,8 @@ class DynamoDBAdapter():
         self.table = self.conn.Table(table)
         return table.delete_item(Key=keys)
 
-    def get_all_roles(self, countries=[]):
-        table = self.conn.Table(app.config['ROLES'])
-        if not countries:
-            # If no country is specified, get all roles and return as list.
-            return table.scan({}).get("Items", [])
-        else:
-            roles = []
-            # Load data separately for each country because can't query for OR.
-            for country in countries:
-                roles = roles + table.query(
-                    KeyConditions={
-                        'country': {
-                            'AttributeValueList': [country],
-                            'ComparisonOperator': 'EQ'
-                        }
-                    }
-                ).get("Items", [])
-            return roles
-
-    def get_all_users(self, countries=[], attributes=[]):
-        table = self.conn.Table(app.config['USERS'])
+    def get_all(self, table, conditions={}, attributes=[]):
+        table = self.conn.Table(table)
 
         # Assemble scan arguments programatically, by building a dictionary.
         kwargs = {}
@@ -118,59 +104,56 @@ class DynamoDBAdapter():
         if attributes:
             kwargs["AttributesToGet"] = attributes
 
-        if not countries:
-            # If no country is specified, get all users and return as list.
+        if not conditions:
+            # If no conditions are specified, get all users and return as list.
             return table.scan(**kwargs).get("Items", [])
 
         else:
-            users = {}
+            items = []
             # Load data separately for each country
             # ...because Scan can't perform OR on CONTAINS
-            for country in countries:
-
+            for field, values in conditions:
                 kwargs["ScanFilter"] = {
-                    'countries': {
-                        'AttributeValueList': [country],
+                    field: {
+                        'AttributeValueList': values,
                         'ComparisonOperator': 'CONTAINS'
                     }
                 }
+                items += table.scan(**kwargs).get("Items", [])
 
-                # Get and combine the users together in a no-duplications dict.
-                for user in table.scan(**kwargs).get("Items", []):
-                    users[user["username"]] = user
-
-            # Convert the dict to a list by getting values.
-            return list(users.values())
+            # Return a list of results without duplicates
+            return [dict(t) for t in set([tuple(d.items()) for d in items])]
 
 
 class PostgreSQLAdapter():
 
-    STRUCTURE = {
-        app.config['USERS']: [
-            ("username", sql.SQL("username VARCHAR(50) PRIMARY KEY")),
-            ("data",  sql.SQL("data JSON"))
-        ],
-        app.config['ROLES']: [
-            ("country", sql.SQL("country VARCHAR(50)")),
-            ("role", sql.SQL("role VARCHAR(50)")),
-            ("data", sql.SQL("data JSON"))
-        ]
-    }
+    def __init__(self):
+        self.structure = {
+            app.config['USERS']: [
+                ("username", sql.SQL("username VARCHAR(50) PRIMARY KEY")),
+                ("data",  sql.SQL("data JSON"))
+            ],
+            app.config['ROLES']: [
+                ("country", sql.SQL("country VARCHAR(50)")),
+                ("role", sql.SQL("role VARCHAR(50)")),
+                ("data", sql.SQL("data JSON"))
+            ]
+        }
 
     def drop(self):
         try:
-            logging.info("Dropping database")
+            logging.info("Dropping tables")
             conn = psycopg2.connect(
-                dbname="postgres",
+                dbname="meerkat_auth",
                 user="postgres",
                 host="db"
             )
-            # Cannot drop or create from within a DB transaction.
-            # http://initd.org/psycopg/docs/connection.html#connection.autocommit
-            with conn.cursor() as cur:
-                conn.autocommit = True
-                cur.execute("DROP DATABASE meerkat_auth;")
-                conn.close()
+
+            for table in self.structure.keys():
+                conn.cursor().execute("DROP TABLE {};".format(table))
+                conn.commit()
+
+            conn.close()
 
         except psycopg2.ProgrammingError:
             logging.info("No database exists to drop.")
@@ -181,7 +164,7 @@ class PostgreSQLAdapter():
         self._create_tables()
 
     def list(self):
-        for table in PostgreSQLAdapter.STRUCTURE.keys():
+        for table in self.structure.keys():
             logging.info("Listing all records in {} table".format(table))
             cur = self.conn().cursor()
             cur.execute(sql.SQL("SELECT data from {}").format(
@@ -221,7 +204,7 @@ class PostgreSQLAdapter():
             self._create_tables()
 
     def _create_tables(self):
-        for table, structure in PostgreSQLAdapter.STRUCTURE.items():
+        for table, structure in self.structure.items():
             # Only create non-existant tables, so first check if table exists.
             try:
                 logging.info("Checking if table {} exists.".format(table))
@@ -289,7 +272,7 @@ class PostgreSQLAdapter():
         data = {**key, 'data': Json(attributes)}
         values = sql.SQL(", ").join(map(
             lambda x: sql.Literal(data[x[0]]),
-            PostgreSQLAdapter.STRUCTURE[table]
+            self.structure[table]
         ))
 
         # Securely build sql query to avoid sql injection.
@@ -325,31 +308,7 @@ class PostgreSQLAdapter():
         self.conn.commit()
         cur.close()
 
-    def get_all_roles(self, countries=[]):
-        # Securely compose sql list of conditions.
-        if countries:
-            conditions = sql.SQL(" where country in ({})").format(
-                sql.SQL(", ").join([sql.Literal(x) for x in countries])
-            )
-        else:
-            conditions = sql.SQL("")
-
-        # Build the secure SQL query
-        query = sql.SQL("SELECT data from {}{};").format(
-            sql.Identifier(app.config['ROLES']),
-            conditions
-        )
-        logging.debug("Read query: {}".format(query.as_string(self.conn)))
-
-        # Execute and fetch JSON data as a list of dicts
-        # (Key data is merged into JSON data before writing to db.)
-        cur = self.conn.cursor()
-        cur.execute(query)
-        results = [x[0] for x in cur.fetchall()]  # Just JSON data
-        cur.close()
-        return results
-
-    def get_all_users(self, countries=[], attributes=[]):
+    def get_all(self, table, conditions={}, attributes=[]):
         # Securely compose sql list of attributes.
         if attributes:
             attributes = sql.SQL(", ").join(map(
@@ -360,9 +319,10 @@ class PostgreSQLAdapter():
             attributes = sql.SQL("data")
 
         # Securely compose sql list of conditions.
-        if countries:
-            condition = sql.SQL(" where data->>'country' in ({});").format(
-                sql.SQL(", ").join([sql.Literal(x) for x in countries])
+        for field, values in conditions:
+            condition = sql.SQL(" where data->>{} in ({});").format(
+                sql.Identifier(field),
+                sql.SQL(", ").join([sql.Literal(x) for x in values])
             )
         else:
             condition = sql.SQL("")
@@ -370,7 +330,7 @@ class PostgreSQLAdapter():
         # Securely build sql query to avoid sql injection.
         query = sql.SQL("SELECT {} from {}{};").format(
             attributes,
-            sql.Identifier(app.config['USERS']),
+            sql.Identifier(table),
             condition
         )
         logging.debug("Read query: {}".format(query.as_string(self.conn)))

--- a/meerkat_auth/role.py
+++ b/meerkat_auth/role.py
@@ -1,4 +1,4 @@
-from meerkat_auth import app, db
+from meerkat_auth import app
 import logging
 
 
@@ -85,7 +85,7 @@ class Role:
 
         # Use the db adapter to write the object to the database.
         logging.debug("Object validated. Writing object to database.")
-        response = db.write(
+        response = app.db.write(
             app.config['ROLES'],
             {'country': self.country, 'role': self.role},
             {'description': self.description,
@@ -153,7 +153,7 @@ class Role:
         logging.debug(
             'Loading role "' + role + '" for ' + country + ' from database.'
         )
-        response = db.read(
+        response = app.db.read(
             app.config['ROLES'],
             {'country': country, 'role': role},
         )
@@ -185,7 +185,7 @@ class Role:
             The amazon dynamodb response.
         """
         logging.debug('Deleting role ' + role + ' in ' + country)
-        response = db.delete(
+        response = app.db.delete(
             app.config['ROLES'],
             {'country': country, 'role': role}
         )
@@ -240,7 +240,10 @@ class Role:
             countries = [countries]
 
         # Use the db adapter to get and return all roles.
-        return db.get_all_roles(countries)
+        conditions = {'countries': countries}
+        response = app.db.get_all(app.config['ROLES'], conditions)
+        logging.warning(response)
+        return response
 
 
 class InvalidRoleException(Exception):

--- a/meerkat_auth/test/test_api.py
+++ b/meerkat_auth/test/test_api.py
@@ -7,7 +7,7 @@ Unit tests for REST API resources in Meerkat Auth.
 from meerkat_auth.user import User
 from meerkat_auth.role import Role
 from unittest import mock
-from meerkat_auth import app
+from meerkat_auth import app, db_adapters
 import meerkat_auth
 import json
 import unittest
@@ -15,15 +15,6 @@ import jwt
 import calendar
 import time
 import logging
-import boto3
-import os
-
-
-# Need this module to be importable without the whole of meerkat_auth config.
-# Directly load secret settings file from which to import required config.
-# File must define JWT_COOKIE_NAME, JWT_ALGORITHM and JWT_PUBLIC_KEY variables.
-filename = os.environ.get('MEERKAT_AUTH_SETTINGS')
-exec(compile(open(filename, "rb").read(), filename, 'exec'))
 
 
 class MeerkatAuthAPITestCase(unittest.TestCase):
@@ -32,61 +23,78 @@ class MeerkatAuthAPITestCase(unittest.TestCase):
         """Setup for testing"""
         app.config.from_object('meerkat_auth.config.Testing')
         app.config.from_envvar('MEERKAT_AUTH_SETTINGS')
-        User.DB = boto3.resource(
-            'dynamodb',
-            endpoint_url=app.config['DB_URL'],
-            region_name='eu-west-1'
-        )
-        Role.DB = boto3.resource(
-            'dynamodb',
-            endpoint_url=app.config['DB_URL'],
-            region_name='eu-west-1'
-        )
         self.app = meerkat_auth.app.test_client()
-        logging.warning(app.config['DB_URL'])
-        # The database should have the following objects already in it
+
+        # Mock the db
+        app.db = mock.create_autospec(db_adapters.DynamoDBAdapter)
+        self.db_data = {
+            app.config['ROLES']: {},
+            app.config['USERS']: {}
+        }
+
+        def build_key(keys):
+            return '-'.join(["{}:{}".format(k, v) for (k, v) in keys.items()])
+
+        def read_effect(table, keys, attributes=[]):
+            item = self.db_data[table].get(build_key(keys), {})
+            return {k: item[k] for k in item if k not in attributes}
+
+        def write_effect(table, keys, attributes):
+            self.db_data[table][build_key(keys)] = {**attributes, **keys}
+
+        def delete_effect(table, keys):
+            print(self.db_data[table][build_key(keys)])
+            del self.db_data[table][build_key(keys)]
+
+        app.db.read.side_effect = read_effect
+        app.db.write.side_effect = write_effect
+        app.db.delete.side_effect = read_effect
+
+        # Initialise the db
         roles = [
-            Role('demo', 'registered', 'Registered description.', []),
-            Role('demo', 'personal', 'Personal description.', ['registered']),
-            Role('demo', 'shared', 'Shared description.', ['registered']),
-            Role('demo', 'manager', 'Manager.', ['personal', 'shared']),
-            Role('jordan', 'registered', 'Registered description.', []),
-            Role('jordan', 'personal', 'Personal description.', ['registered'])
+            {'country': 'demo', 'role': 'registered',
+             'description': 'Registered.', 'parents': []},
+            {'country': 'demo', 'role': 'personal',
+             'description': 'Personal.', 'parents': ['registered']},
+            {'country': 'demo', 'role': 'shared',
+             'description': 'Shared.', 'parents': ['registered']},
+            {'country': 'demo', 'role': 'manager',
+             'description': 'Manager.', 'parents': ['personal', 'shared']},
+            {'country': 'jordan', 'role': 'registered',
+             'description': 'Registered.', 'parents': []},
+            {'country': 'jordan', 'role': 'personal',
+             'description': 'Personal.', 'parents': ['registered']}
         ]
-
-        # Update objects in case something else has spuriously has changed them
         for role in roles:
-            role.to_db()
-
-        # Put into the database a couple of test users
-        users = [
-            User(
-                'testUser1',
-                'test1@test.org.uk',
-                User.hash_password('password1'),
-                ['demo', 'jordan'],
-                ['manager', 'personal'],
-                data={
-                    'name': 'Testy McTestface'
-                }
-            ),
-            User(
-                'testUser2',
-                'test2@test.org.uk',
-                User.hash_password('password2'),
-                ['demo'],
-                ['personal'],
-                data={
-                    'name': 'Tester McTestFace'
-                }
+            keys = {'country': role['country'], 'role': role['role']}
+            write_effect(
+                app.config['ROLES'],
+                keys,
+                {k: role[k] for k in role if k not in keys}
             )
-        ]
-        for user in users:
-            user.to_db()
 
-    def tearDown(self):
-        """Tear down after testing."""
-        User.delete('testUser')
+        users = [
+            {'username': 'testUser1',
+             'email': 'test1@test.org.uk',
+             'password': User.hash_password('password1'),
+             'countries': ['demo', 'jordan'],
+             'roles': ['manager', 'personal'],
+             'data': {'name': 'Testy McTestface'}},
+            {'username': 'testUser2',
+             'email': 'test2@test.org.uk',
+             'password': User.hash_password('password2'),
+             'countries': ['demo', 'jordan'],
+             'roles': ['manager', 'personal'],
+             'data': {'name': 'Tester McTestface'}}
+        ]
+
+        for user in users:
+            keys = {'username': user['username']}
+            write_effect(
+                app.config['USERS'],
+                keys,
+                {k: user[k] for k in user if k not in keys}
+            )
 
     @mock.patch('flask.Response.set_cookie')
     def test_login(self, request_mock):
@@ -110,8 +118,8 @@ class MeerkatAuthAPITestCase(unittest.TestCase):
         # Decode the jwt and check it is structured as expected.
         payload = jwt.decode(
             response_jwt,
-            JWT_PUBLIC_KEY,
-            algorithms=JWT_ALGORITHM
+            app.config['JWT_PUBLIC_KEY'],
+            algorithms=app.config['JWT_ALGORITHM']
         )
         self.assertTrue(payload.get('usr', False))
         self.assertTrue(payload.get('exp', False))
@@ -186,8 +194,8 @@ class MeerkatAuthAPITestCase(unittest.TestCase):
         # Assemble the user that went in & the user that was taken out the func
         user_out = jwt.decode(
             json.loads(response.data.decode('UTF-8'))['jwt'],
-            JWT_PUBLIC_KEY,
-            algorithms=JWT_ALGORITHM
+            app.config['JWT_PUBLIC_KEY'],
+            algorithms=app.config['JWT_ALGORITHM']
         )
         user_in = user.to_dict()
 

--- a/meerkat_auth/test/test_role.py
+++ b/meerkat_auth/test/test_role.py
@@ -6,10 +6,9 @@ Unit tests for the utility class role in Meerkat Auth.
 """
 
 from meerkat_auth.role import Role, InvalidRoleException
-from meerkat_auth import app
+from meerkat_auth import app, db_adapters
+from unittest import mock
 import unittest
-import logging
-import boto3
 
 
 class MeerkatAuthRoleTestCase(unittest.TestCase):
@@ -18,88 +17,97 @@ class MeerkatAuthRoleTestCase(unittest.TestCase):
         """Setup for testing"""
         app.config.from_object('meerkat_auth.config.Testing')
         app.config.from_envvar('MEERKAT_AUTH_SETTINGS')
-        Role.DB = boto3.resource(
-            'dynamodb',
-            endpoint_url=app.config['DB_URL'],
-            region_name='eu-west-1'
+        app.db = mock.create_autospec(db_adapters.DynamoDBAdapter)
+        self.roles = {
+            'registered': {
+                'country': 'demo', 'role': 'registered',
+                'description': 'Registered.', 'parents': []
+            },
+            'personal': {
+                'country': 'demo', 'role': 'personal',
+                'description': 'Personal.', 'parents': ['registered']
+            },
+            'shared': {
+                'country': 'demo', 'role': 'shared',
+                'description': 'Shared.', 'parents': ['registered']
+            },
+            'manager': {
+                'country': 'demo', 'role': 'manager',
+                'description': 'Manager.', 'parents': ['personal', 'shared']
+            },
+            'testrole': {
+                'country': 'demo', 'role': 'testrole', 'visible': ['manager'],
+                'description': 'Manager.', 'parents': []
+            }
+        }
+
+    def test_to_db(self):
+        """Test the role to_db() method"""
+        role = self.roles['testrole']
+        Role(**role).to_db()
+        app.db.write.assert_called_with(
+            app.config['ROLES'],
+            {'country': role['country'], 'role': role['role']},
+            {'description': role['description'],
+             'parents': role['parents'],
+             'visible': role['visible']}
         )
-        logging.warning(app.config['USERS'])
-        logging.warning(app.config['ROLES'])
-        logging.warning(app.config['DB_URL'])
 
-        # Put some roles into the test db.
-        roles = [
-            Role('demo', 'registered', 'Registered.', []),
-            Role('demo', 'personal', 'Personal.', ['registered']),
-            Role('demo', 'shared', 'Shared.', ['registered']),
-            Role('demo', 'manager', 'Manager.', ['personal', 'shared']),
-            Role('jordan', 'registered', 'Registered.', []),
-            Role('jordan', 'personal', 'Personal.', ['registered'])
-        ]
-        for role in roles:
-            role.to_db()
-
-        # Store roles indexed in a manner  helpful for reference in the tests.
-        self.demo_roles = {}
-        self.jordan_roles = {}
-        for role in roles:
-            if role.country == 'demo':
-                self.demo_roles[role.role] = role
-            elif role.country == 'jordan':
-                self.jordan_roles = role
-
-    def tearDown(self):
-        """Tear down after testing."""
-        # Delete the roles in the database after finishing the tests.
-        table = Role.DB.Table(app.config['ROLES'])
-        response = table.scan()
-        with table.batch_writer() as batch:
-            for role in response.get('Items', []):
-                batch.delete_item(
-                    Key={
-                        'country': role['country'],
-                        'role': role['role']
-                    }
-                )
-
-
-    def test_io(self):
-        """Test the Role class' database writing/reading/deleting functions."""
-
-        # Create a test role object.
-        role1 = Role(
-            'demo',
-            'testRole',
-            'Test role description.',
-            ['personal']
+    def test_from_db(self):
+        """Test the role from_db() method"""
+        role = self.roles['testrole']
+        app.db.read.side_effect = [role]
+        output = Role.from_db(role['country'], role['role'])
+        app.db.read.assert_called_with(
+            app.config['ROLES'],
+            {'country': role['country'], 'role': role['role']}
         )
-        print('role1:\n' + repr(role1))
-
-        # Put the role into the database and take it out again.
-        role1.to_db()
-        role2 = Role.from_db('demo', 'testRole')
-        print('role2:\n' + repr(role1))
-
-        # Check that the role out of the database equals the role that went in.
-        self.assertEqual(role1.country, role2.country)
-        self.assertEqual(role1.role, role2.role)
-        self.assertEqual(role1.description, role2.description)
-        self.assertEqual(role1.parents, role2.parents)
-
-        # Check the role can be deleted and then from_db() raises exception.
-        Role.delete(role1.country, role1.role)
+        self.assertEqual(Role(**role), output)
+        app.db.read.side_effect = [None]  # Raises InvalidRole Exception properly.
         self.assertRaises(
-            Exception,
-            lambda: Role.from_db(role1.country, role1.role)
+            InvalidRoleException,
+            lambda: Role.from_db(role['country'], role['role'])
+        )
+
+    def test_delete(self):
+        """Test the role delete() method"""
+        role = self.roles['testrole']
+        Role.delete(role['country'], role['role'])
+        app.db.delete.assert_called_with(
+            app.config['ROLES'],
+            {'country': role['country'], 'role': role['role']}
+        )
+
+    def test_get_all(self):
+        """Test the role get_all() method"""
+        roles = list(self.roles.values())
+        app.db.get_all.side_effect = [roles, roles]
+        response = Role.get_all('demo')
+        app.db.get_all.assert_called_with(
+            app.config['ROLES'],
+            {'countries': ['demo']}
+        )
+        for input_role, output_role in zip(roles, response):
+            self.assertDictEqual(input_role, output_role)
+        response = Role.get_all(None)
+        app.db.get_all.assert_called_with(
+            app.config['ROLES'],
+            {'countries': []}
         )
 
     def test_all_parents(self):
-        """Test the Role class private method all_access_objs()."""
+        """Test the role all_access_objs() method."""
 
-        roles = self.demo_roles
+        roles = self.roles
+
+        def side_effect(table, key):
+            app.logger.warning(key['role'])
+            return roles.get(key['role'], None)
+
+        app.db.read.side_effect = side_effect
 
         # Get all the manager parents.
-        parents = roles['manager'].all_access()
+        parents = Role(**roles['manager']).all_access()
         # Check the correct list is returned
         print("Manager parents: " + str(parents))
         self.assertEqual(len(parents), 4)
@@ -109,7 +117,7 @@ class MeerkatAuthRoleTestCase(unittest.TestCase):
         self.assertIn('manager', parents)
 
         # Get all the private parents.
-        parents = roles['personal'].all_access()
+        parents = Role(**roles['personal']).all_access()
         # Check the correct list is returned
         print("private parents: " + str(parents))
         self.assertEqual(len(parents), 2)
@@ -117,48 +125,34 @@ class MeerkatAuthRoleTestCase(unittest.TestCase):
         self.assertIn('personal', parents)
 
         # Get all the registered parents.
-        parents = roles['registered'].all_access()
+        parents = Role(**roles['registered']).all_access()
         # Check the correct list is returned
         print("Registered parents: " + str(parents))
         self.assertEqual(len(parents), 1)
         self.assertIn('registered', parents)
 
     def test_validate(self):
-        """Test the Role validate functions."""
+        """Test the role validate functions."""
+        roles = self.roles
 
-        roles = self.demo_roles
+        def side_effect(table, key):
+            app.logger.warning(key['role'])
+            return roles.get(key['role'], None)
+
+        app.db.read.side_effect = side_effect
 
         # Check that a valid role passes the validate check.
         try:
             Role.validate_role('demo', 'manager')
-            roles['manager'].validate()
+            Role(**roles['manager']).validate()
         except InvalidRoleException as e:
             self.fail(repr(e))
 
         # Check that breaking the ancestor tree breaks the validation.
-        Role.delete('demo', 'shared')
+        del roles['shared']
         self.assertRaises(
             InvalidRoleException, lambda: Role.validate_role('demo', 'manager')
         )
         self.assertRaises(
-            InvalidRoleException, lambda: roles['manager'].validate()
+            InvalidRoleException, lambda: Role(**roles['manager']).validate()
         )
-
-    def test_get_all(self):
-        """Test the staticmethod get_all()."""
-
-        # Request just roles from demo.
-        response = Role.get_all('demo')
-        self.assertEqual(len(response), 4)
-
-        # Request just roles from jordan.
-        response = Role.get_all(['jordan'])
-        self.assertEqual(len(response), 2)
-
-        # Request all roles.
-        response = Role.get_all(None)
-        self.assertEqual(len(response), 6)
-
-        # Request all roles.
-        response = Role.get_all(['demo', 'jordan'])
-        self.assertEqual(len(response), 6)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ raven[flask]==6.0.0
 sphinx==1.6.7
 sphinxcontrib-httpdomain==1.6.0
 sphinxcontrib-napoleon==0.6.1
+psycopg2-binary==2.7.4


### PR DESCRIPTION
Jordan are requiring us to migrate our cloud hosted infrastructure to the MoH data center.  As part of this we can no longer use the production ready cloud-housted dynamodb service.  This PR abstracts out the db interaction from auth into two DB adapters - a DynamoDB adapter and a PostgreSQL adapter. Which adapter to use is configurable from the auth config.py and an environment variable MEERKAT_DB_ADAPTER.  

At present this is fairly rough code, without doc strings or any new tests.  We have to decide how much time we have to clean this up. 