### PR TITLE
Consul authenticates to api & enable consul authentication

### DIFF
--- a/local_db.py
+++ b/local_db.py
@@ -146,6 +146,11 @@ if args.populate:
 
         ]
 
+    for country in all_countries:
+        roles += [
+            Role(country, 'consul', 'Access to consul integration service.', [])
+        ]
+
     # Create the jordan access network
     roles += [
         Role('jordan', 'reports', ' ', []),
@@ -530,6 +535,18 @@ if args.populate:
         ['emails', 'reports'] + ['emails', 'reports', 'all'],
         state='new'
     )]
+
+    # Create an account to authenticate request to consul
+    users += [User(
+        'consul-dev-user',
+        'consul-dev-user@test.org.uk',
+        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+        all_countries,
+        ['consul']*len(all_countries),
+        state='new'
+    )]
+
     # Create an account to authenticate email sending.
     users += [User(
         'server',

--- a/local_db.py
+++ b/local_db.py
@@ -328,11 +328,8 @@ if args.populate:
             ['pip', 'clinic'],
             data={'name': {'value': 'Pip user'}},
             state='new'
-        )
-    ]
-
-    # Create some madagascar accounts.
-    users += [
+        ),
+        # Create some madagascar accounts.
         User(
             'madagascar-reports',
             'reports@madagascartest.org.uk',
@@ -438,133 +435,130 @@ if args.populate:
                 ['download', 'admin'],
                 data={'name': {'value': 'Central Administrator'}},
                 state='new'
-            )
-        ]
+            )]
 
-    # Create a CTC account for somalia
-    users += [User(
-        'ctc',
-        'ctc@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia'],
-        ['ctc', 'dashboard'],
-        data={'name': {'val': 'CTC User'}},
-        state='new'
-    ), User(
-        'reports-som-ctc',
-        'ctc@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia'],
-        ['ctc', 'reports'],
-        data={'name': {'val': 'CTC Reports'}, 'TOKEN_LIFE': {'val': '60'}},
-        state='new'
-    ), User(
-        'reports-som-sc',
-        'sc@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia'],
-        ['sc', 'reports'],
-        data={'name': {'val': 'SC Reports'}, 'TOKEN_LIFE': {'val': '60'}},
-        state='new'
-    )]
+    users += [
+        # Create a CTC account for somalia
+        User(
+            'ctc',
+            'ctc@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia'],
+            ['ctc', 'dashboard'],
+            data={'name': {'val': 'CTC User'}},
+            state='new'
+        ), User(
+            'reports-som-ctc',
+            'ctc@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia'],
+            ['ctc', 'reports'],
+            data={'name': {'val': 'CTC Reports'}, 'TOKEN_LIFE': {'val': '60'}},
+            state='new'
+        ), User(
+            'reports-som-sc',
+            'sc@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia'],
+            ['sc', 'reports'],
+            data={'name': {'val': 'SC Reports'}, 'TOKEN_LIFE': {'val': '60'}},
+            state='new'
+        ),
+        # Create a location restricted account for somalia
+        User(
+            'puntland',
+            'puntland@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia', 'somalia'],
+            ['puntland', 'download', 'other'],
+            data={'name': {'val': 'Puntland User'}},
+            state='new'
+        ), User(
+            'somaliland',
+            'somaliland@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia', 'somalia'],
+            ['somaliland', 'download', 'other'],
+            data={'name': {'val': 'somaliland User'}},
+            state='new'
+        ), User(
+            'southcentral',
+            'southcentral@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia', 'somalia'],
+            ['southcentral', 'download', 'other'],
+            data={'name': {'val': 'southcentral User'}},
+            state='new'
+        ), User(
+            'somalia',
+            'somalia@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ['somalia', 'somalia'],
+            ['download', 'other'],
+            data={'name': {'val': 'somalia User'}},
+            state='new'
+        ),
+        # Create an overall root acount with access to everything.
+        User(
+            'root',
+            'root@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            all_countries,
+            ['root']*len(all_countries),
+            data={'name': {'val': 'Supreme Omnipotent Overlord'}},
+            state='new'
+        ),
+        # Create an account to authenticate email sending.
+        User(
+            'report-emails',
+            'report-emails@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            countries + countries + ['jordan', 'jordan', 'jordan'] +
+            ['madagascar', 'madagascar'] + ['somalia', 'somalia', 'somalia'],
+            ['registered' for c in countries] +
+            ['emails' for c in countries] + ['reports', 'emails', 'all'] +
+            ['emails', 'reports'] + ['emails', 'reports', 'all'],
+            state='new'
+        ),
+        # Create an account to authenticate request to consul
+        User(
+            'consul-dev-user',
+            'consul-dev-user@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            all_countries,
+            ['consul']*len(all_countries),
+            state='new'
+        ),
+        # Create an account to authenticate email sending.
+        User(
+            'server',
+            'server@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ["meerkat"],
+            ["hermes"],
+            state='new'
+        ), User(
+            'slack',
+            'slack@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            ["meerkat"],
+            ["slack"],
+            state='new'
+        )
+    ]
 
-    # Create a location restricted account for somalia
-    users += [User(
-        'puntland',
-        'puntland@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia', 'somalia'],
-        ['puntland', 'download', 'other'],
-        data={'name': {'val': 'Puntland User'}},
-        state='new'
-    ), User(
-        'somaliland',
-        'somaliland@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia', 'somalia'],
-        ['somaliland', 'download', 'other'],
-        data={'name': {'val': 'somaliland User'}},
-        state='new'
-    ), User(
-        'southcentral',
-        'southcentral@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia', 'somalia'],
-        ['southcentral', 'download', 'other'],
-        data={'name': {'val': 'southcentral User'}},
-        state='new'
-    ), User(
-        'somalia',
-        'somalia@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ['somalia', 'somalia'],
-        ['download', 'other'],
-        data={'name': {'val': 'somalia User'}},
-        state='new'
-    )]
-
-    # Create an overall root acount with access to everything.
-    users += [User(
-        'root',
-        'root@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        all_countries,
-        ['root']*len(all_countries),
-        data={'name': {'val': 'Supreme Omnipotent Overlord'}},
-        state='new'
-    )]
-
-    # Create an account to authenticate email sending.
-    users += [User(
-        'report-emails',
-        'report-emails@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        countries + countries + ['jordan', 'jordan', 'jordan'] +
-        ['madagascar', 'madagascar'] + ['somalia', 'somalia', 'somalia'],
-        ['registered' for c in countries] +
-        ['emails' for c in countries] + ['reports', 'emails', 'all'] +
-        ['emails', 'reports'] + ['emails', 'reports', 'all'],
-        state='new'
-    )]
-
-    # Create an account to authenticate request to consul
-    users += [User(
-        'consul-dev-user',
-        'consul-dev-user@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        all_countries,
-        ['consul']*len(all_countries),
-        state='new'
-    )]
-
-    # Create an account to authenticate email sending.
-    users += [User(
-        'server',
-        'server@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ["meerkat"],
-        ["hermes"],
-        state='new'
-    ), User(
-        'slack',
-        'slack@test.org.uk',
-        ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
-         'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        ["meerkat"],
-        ["slack"],
-        state='new'
-    )]
     try:
         # Get developer accounts from file to be inserted into local database.
         fpath = (path.dirname(path.realpath(__file__)) +

--- a/local_db.py
+++ b/local_db.py
@@ -539,6 +539,16 @@ if args.populate:
             ['consul']*len(all_countries),
             state='new'
         ),
+        # Create an account to authenticate download requests to api
+        User(
+            'api-dev-user',
+            'api-dev-user@test.org.uk',
+            ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
+             'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
+            all_countries,
+            ['admin']*len(all_countries),
+            state='new'
+        ),
         # Create an account to authenticate email sending.
         User(
             'server',

--- a/local_db.py
+++ b/local_db.py
@@ -123,6 +123,10 @@ if args.populate:
     # TODO: Need a clever solution to match dev to deployment here.
     # Maybe we define roles for dev and deployment in a sngle file and import.
     countries = ['demo', 'rms']
+    all_countries = countries + [
+        'jordan', 'madagascar', 'somalia',
+        'meerkat', 'somaliland', 'southcentral', 'puntland'
+    ]
     roles = []
 
     for country in countries:
@@ -502,17 +506,13 @@ if args.populate:
     )]
 
     # Create an overall root acount with access to everything.
-    root_countries = countries + [
-        'jordan', 'madagascar', 'somalia',
-        'meerkat', 'somaliland', 'southcentral', 'puntland'
-    ]
     users += [User(
         'root',
         'root@test.org.uk',
         ('$pbkdf2-sha256$29000$UAqBcA6hVGrtvbd2LkW'
          'odQ$4nNngNTkEn0d3WzDG31gHKRQ2sVvnJuLudwoynT137Y'),
-        root_countries,
-        ['root']*len(root_countries),
+        all_countries,
+        ['root']*len(all_countries),
         data={'name': {'val': 'Supreme Omnipotent Overlord'}},
         state='new'
     )]

--- a/meerkat_auth/user.py
+++ b/meerkat_auth/user.py
@@ -31,8 +31,8 @@ class User:
                  countries,
                  roles,
                  state="live",
-                 updated=datetime.now().isoformat(),
-                 creation=datetime.now().isoformat(),
+                 updated=None,
+                 creation=None,
                  data={}):
         """Create a User object."""
 
@@ -43,6 +43,10 @@ class User:
         self.countries = countries
         self.roles = roles
         self.state = state
+        if not creation:
+            creation = datetime.now().isoformat()
+        if not updated:
+            updated = datetime.now().isoformat()
         self.creation = creation
         self.updated = updated
         self.data = data


### PR DESCRIPTION
Changes needed for consul to auth for internal meerkat_api requests.
Added user accounts for meerkat_abacus to auth when requesting consul.

Some minor bug fixes done on the go. Changes should be atomic packed in separate commits.