### PR TITLE
Fix access right to delete auth users.

### DIFF
--- a/meerkat_auth/views/users.py
+++ b/meerkat_auth/views/users.py
@@ -4,6 +4,8 @@ users.py
 A Flask Blueprint module for the user manager page.
 """
 from flask import Blueprint, render_template, request, jsonify, g, abort
+from werkzeug.exceptions import HTTPException
+
 from meerkat_auth.user import User, InvalidCredentialException
 from meerkat_auth.role import InvalidRoleException
 from meerkat_auth.authorise import auth

--- a/meerkat_auth/views/users.py
+++ b/meerkat_auth/views/users.py
@@ -238,8 +238,13 @@ def delete_users():
     for username in users:
         try:
             # Check current user has access to delete the specified user.
-            user = User.from_db(username)
-            auth.check_auth(user.roles, user.countries, logic='AND')
+            user_to_delete = User.from_db(username)
+            try:
+                auth.check_auth(['admin'], ['meerkat'])
+            except HTTPException:
+                countries_list = user_to_delete.countries
+                admin_role_list = ['admin'] * len(countries_list)
+                auth.check_auth(admin_role_list, countries_list, logic='AND')
             logging.warning(
                 g.payload['usr'] + ' is deleting account ' + str(username)
             )


### PR DESCRIPTION
Currently deploy server has problems with removing deployment auth user accounts.
Errors like this happens. Auth response to `delete_users` endpoint with deploy-server credentials (error code 200!):
```
ERROR: There was an error deleting some users.
Cannot delete "mad-development-3e3141": 403: Forbidden
```
And i auth logs:
```
Jul 16 10:57:35 auth-master-ab475a meerkat_auth[2975]: WARNING:root:Invalid token - Access Denied: User doesn't have required access levels for this page: download.
```
This happens because `deploy-server` account has role `admin` for general country `meerkat`. Nevertheless if it had role `admin` for `madagascar` it still woudn't work.

I guess that current role checking for user deletion is buggy. There's my proposed solution:
1) Check if user sending request is `admin` of `meerkat`
2) If not, check if he's ad `admin` for *all* of countries the to-delete user has roles for.